### PR TITLE
fix(dante-ctf): add year in title

### DIFF
--- a/content/dantectf_2023/_index.md
+++ b/content/dantectf_2023/_index.md
@@ -1,5 +1,5 @@
 ---
-title: DanteCTF
+title: DanteCTF 2023
 date: 2023-06-02T13:16:05+03:00
 tags:
 - forensics


### PR DESCRIPTION
Small fix to have year in the title. Will be useful later to avoid confusion.