### PR TITLE
feat: add option to display author for writeups

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -21,6 +21,12 @@
                 {{ end }}
                 {{ end }}
             </div>
+            {{ if .Params.Author }}
+            <div class="author">
+                {{ $member := index (where .Site.Params.members "name" .Params.Author) 0 }}
+                <span>writeup by: <a href="{{ $member.link }}">{{ $member.name }}</a></span>
+            </div>
+            {{ end }}
         </div>
 
         {{ if isset .Params "tldr" }}


### PR DESCRIPTION
very easy to implement. the link on author leads to the link put in .config. we could also do it such that the link leads to about, but I think it wouldn't make much sense.


this is how it would look like:
![image](https://github.com/dothidden/writeups/assets/30214214/910e63d2-c631-4ed7-84b5-82faf2838377)

what do you think?

ps: this is rebased into #8 (so I could get the authors)